### PR TITLE
Fix broken URL in README Our Files Are Belong Only To Us

### DIFF
--- a/challenges/web/our_files_are_belong_only_to_us/README.md
+++ b/challenges/web/our_files_are_belong_only_to_us/README.md
@@ -3,6 +3,6 @@
 ### Acknowledgement
 It was revealed after magpieCTF 2022 that the author of this challenge copied the code from another challenge written and put out by justCTF and did not credit the original author.  Full credit goes to disconnect3d for the original challenge and bug discovery that this challenge was based upon.
 
-You can find the original challenge here: https://github.com/justcatthefish/justctf-2020/tree/master/challenges/web_gofs>
+You can find the original challenge here: https://github.com/justcatthefish/justctf-2020/tree/master/challenges/web_gofs
 
 and a link to their original bug report here: https://github.com/golang/go/issues/40940


### PR DESCRIPTION
The URL to the original challenge was broken, so I fixed it by removing the trailing > character